### PR TITLE
feat: add docsUrl configuration (#51)

### DIFF
--- a/packages/astrobook/README.md
+++ b/packages/astrobook/README.md
@@ -91,6 +91,44 @@ export default defineConfig({
 })
 ```
 
+### `docsUrl`
+
+You can use the `docsUrl` option to specify the base URL to your stories docs. The default directory is the Astro base url.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config'
+import astrobook from 'astrobook'
+
+export default defineConfig({
+  integrations: [
+    astrobook({
+      docsUrl: 'docs',
+    }),
+    /* ...other integrations */
+  ],
+})
+```
+
+### `onlyDev`
+
+You can use the `onlyDev` option to specify if you want to render the docs only on dev commands or also on the build command.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config'
+import astrobook from 'astrobook'
+
+export default defineConfig({
+  integrations: [
+    astrobook({
+      onlyDev: true,
+    }),
+    /* ...other integrations */
+  ],
+})
+```
+
 ## Advanced
 
 ### Toggle theme via message

--- a/packages/core/src/astro-integration.ts
+++ b/packages/core/src/astro-integration.ts
@@ -12,9 +12,19 @@ export function createAstrobookIntegration(
   return {
     name: 'astrobook/core',
     hooks: {
-      'astro:config:setup': async ({ updateConfig, injectRoute, config }) => {
+      'astro:config:setup': async ({
+        updateConfig,
+        injectRoute,
+        command,
+        config,
+      }) => {
+        if (command === 'build' && options?.onlyDev) {
+          return
+        }
+
         const rootDir = path.resolve(options?.directory || '.')
-        const baseUrl = config.base || ''
+        const baseUrl = options?.docsUrl || config.base || ''
+
         const routes = await getVirtualRoutes(rootDir)
 
         updateConfig({
@@ -34,7 +44,7 @@ export function createAstrobookIntegration(
           })
         }
         injectRoute({
-          pattern: '/',
+          pattern: `/${baseUrl}`,
           entrypoint: 'astrobook/pages/app.astro',
           prerender: true,
         })

--- a/packages/types/lib/types.d.ts
+++ b/packages/types/lib/types.d.ts
@@ -5,6 +5,20 @@ export interface IntegrationOptions {
    * @default '.'
    */
   directory?: string
+
+  /**
+   * The base docs URL.
+   *
+   * @default ''
+   */
+  docsUrl?: string
+
+  /**
+   * Render the docs only if the command is not 'build'.
+   *
+   * @default ''
+   */
+  onlyDev?: boolean
 }
 
 export interface StoryModule {


### PR DESCRIPTION
with the new docsUrl configuration, you can integrate in existing astro projects with a different sub route.