### PR TITLE
feat: Add custom render support for Astrobook

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -21,3 +21,8 @@ export function isAstroComponentFactory(
     ? false
     : (obj as Record<string, unknown>).isAstroComponentFactory === true
 }
+
+export function applyDecorators<T>(
+  { decorators = [], initialTree, reduceFn }: {decorators: [], initialTree: T, reduceFn: (currentTree: T, decorator: unknown) => T}) {
+  return decorators.slice().reverse().reduce(reduceFn, initialTree)
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -22,7 +22,14 @@ export function isAstroComponentFactory(
     : (obj as Record<string, unknown>).isAstroComponentFactory === true
 }
 
-export function applyDecorators<T>(
-  { decorators = [], initialTree, reduceFn }: {decorators: [], initialTree: T, reduceFn: (currentTree: T, decorator: unknown) => T}) {
+export function applyDecorators<T>({
+  decorators = [],
+  initialTree,
+  reduceFn,
+}: {
+  decorators: []
+  initialTree: T
+  reduceFn: (currentTree: T, decorator: unknown) => T
+}) {
   return decorators.slice().reverse().reduce(reduceFn, initialTree)
 }

--- a/packages/types/lib/types.d.ts
+++ b/packages/types/lib/types.d.ts
@@ -152,39 +152,39 @@ declare global {
 
 /**
  * Represents a story object for a component, typically used improve type hinting in Custom Render Components.
- * 
+ *
  * @template TProps - The type of the props the story accepts.
  */
 export interface StoryObj<TProps = any> {
   /**
    * Arguments (props) to be passed to the component when rendering the story.
    */
-  args?: TProps;
+  args?: TProps
 
   /**
    * Optional decorators to wrap the component with, allowing for reusable wrappers like themes or providers.
-   * Each decorator includes a component and an array of props to apply to it. N.B. these will wrap the story and 
+   * Each decorator includes a component and an array of props to apply to it. N.B. these will wrap the story and
    * will not be rendered within an Astro "island".
    */
   decorators?: Array<{
-    component: unknown;
-    props: Array<Record<string, any>>;
-  }>;
+    component: unknown
+    props: Array<Record<string, any>>
+  }>
 
   /**
    * Custom render configuration for the story.
-   * Allows specifying a different component and optionally skipping decorators, 
+   * Allows specifying a different component and optionally skipping decorators,
    * should you wish to render them in the custom component separatetly.
    */
   render?: {
-    component: unknown;
-    excludeDecorators?: boolean;
-  };
+    component: unknown
+    excludeDecorators?: boolean
+  }
 }
 
 /**
  * Props for a custom render component that optionally receives a story object as input.
- * 
+ *
  * @template T - Must extend `StoryObj` to ensure correct typing.
  */
 export interface CustomRenderProps<T = any> {
@@ -192,5 +192,5 @@ export interface CustomRenderProps<T = any> {
    * The story object to be rendered. Only valid if `T` extends `StoryObj`. Can be safely ignored if the story
    * properties are not used in the Custom Render Component.
    */
-  story: T extends StoryObj ? T : never;
+  story: T extends StoryObj ? T : never
 }

--- a/packages/types/lib/types.d.ts
+++ b/packages/types/lib/types.d.ts
@@ -149,3 +149,48 @@ declare global {
     }
   }
 }
+
+/**
+ * Represents a story object for a component, typically used improve type hinting in Custom Render Components.
+ * 
+ * @template TProps - The type of the props the story accepts.
+ */
+export interface StoryObj<TProps = any> {
+  /**
+   * Arguments (props) to be passed to the component when rendering the story.
+   */
+  args?: TProps;
+
+  /**
+   * Optional decorators to wrap the component with, allowing for reusable wrappers like themes or providers.
+   * Each decorator includes a component and an array of props to apply to it. N.B. these will wrap the story and 
+   * will not be rendered within an Astro "island".
+   */
+  decorators?: Array<{
+    component: unknown;
+    props: Array<Record<string, any>>;
+  }>;
+
+  /**
+   * Custom render configuration for the story.
+   * Allows specifying a different component and optionally skipping decorators, 
+   * should you wish to render them in the custom component separatetly.
+   */
+  render?: {
+    component: unknown;
+    excludeDecorators?: boolean;
+  };
+}
+
+/**
+ * Props for a custom render component that optionally receives a story object as input.
+ * 
+ * @template T - Must extend `StoryObj` to ensure correct typing.
+ */
+export interface CustomRenderProps<T = any> {
+  /**
+   * The story object to be rendered. Only valid if `T` extends `StoryObj`. Can be safely ignored if the story
+   * properties are not used in the Custom Render Component.
+   */
+  story: T extends StoryObj ? T : never;
+}


### PR DESCRIPTION
## Changelog

- Add render property to Story
  - Holds the component used for rendering over the module's default
  - Holds a flag indicating whether decorators should be rendered or not. Will always render them by default. 
- Add StoryObj type so that stories can be typed
- Add CustomRenderProps type so that custom render components can be typed properly

## Notes
Virtual components are not the way. They are finicky and very difficult to get right. Instead, allow the user to define how they want the component to render and have this override the default component. This way users have direct control over how things should render in _any_ framework they decide to use, including ones not officially supported by Astro.

Minor sticking point on the decorators, hence the flag to turn off rendering them, A user will need to manually include them in the custom render component if they want them rendered in the island (React context as a prime example). The expression in virtual-routes.ts has been refactored into a client function so, if a user wants to, they can use this in their custom components.

## Todo
- [ ] Write realistic test scenarios
- [ ] Write documentation